### PR TITLE
Fix LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ ifeq ($(INSTALL),osx)
     SHADER_DIR = Library/glava
 endif
 
-LDFLAGS = $(ASAN) -lpulse -lpulse-simple -pthread $(LDFLAGS_GLFW) -ldl -lm -lX11 -lXext $(LDFLAGS_GLX)
+LDFLAGS += $(ASAN) -lpulse -lpulse-simple -pthread $(LDFLAGS_GLFW) -ldl -lm -lX11 -lXext $(LDFLAGS_GLX)
 
 PYTHON = python
 


### PR DESCRIPTION
The LDFLAGS are currently not inherited, preventing users to append their own. When packaging (for archlinux in this case), it won't inherit the packaging system's default flags.