### PR TITLE
Click through ignore case of setxwintype

### DIFF
--- a/xwin.c
+++ b/xwin.c
@@ -114,7 +114,7 @@ static bool xwin_changeatom(struct gl_wcb* wcb, void* impl, const char* type,
         default:          formatted[t] = c;
         }
     }
-    bool ret = !strcmp(type, "DESKTOP");
+    bool ret = !strcasecmp(type, "DESKTOP");
     char buf[256];
     snprintf(buf, sizeof(buf), fmt, formatted);
     Atom desk = XInternAtom(d, buf, false);


### PR DESCRIPTION
include click through if setxwintype is set to "desktop" (lowercase)

I'm sorry for the mass spam, it's just this repo that I keep making mistakes on and I don't know why...