### PR TITLE
Fix fatal make issue when using XDG_CONFIG_DIRS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ endif
 ifeq ($(INSTALL),unix)
     CFLAGS_INSTALL = -DGLAVA_UNIX
     ifdef XDG_CONFIG_DIRS
-        SHADER_DIR = $(firstword $(subst :, ,$XDG_CONFIG_DIR))/glava
+        SHADER_DIR = $(firstword $(subst :, ,$(XDG_CONFIG_DIRS)))/glava
     else
         SHADER_DIR = etc/xdg/glava
     endif


### PR DESCRIPTION
`$XDG_CONFIG_DIR` is a typo of `$XDG_CONFIG_DIRS` and `$XDG_CONFIG_DIR` expands to the content of `$X` + the string literal `DG_CONFIG_DIR`, so what's actually wanted is `$(XDG_CONFIG_DIRS)`