### PR TITLE
README: Mention Arch Linux binary release (community)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 **GLava** is an OpenGL audio spectrum visualizer. Its primary use case is for desktop windows or backgrounds. Displayed to the left is the `radial` shader module, and [here is a demonstration video](https://streamable.com/dgpj8). Development is active, and reporting issues is encouranged.
 
-**Compiling** (Or use the [`glava-git` AUR package](https://aur.archlinux.org/packages/glava-git/))**:**
+**Compiling** (Or use the Arch Linux [`glava` package](https://www.archlinux.org/packages/community/x86_64/glava/), or the [`glava-git` AUR package](https://aur.archlinux.org/packages/glava-git/))**:**
 
 ```bash
 $ git clone --recursive https://github.com/wacossusca34/glava


### PR DESCRIPTION
GLava is now [part of the official Arch Linux [community] repository](https://www.archlinux.org/packages/community/x86_64/glava/), maintained by me