### PR TITLE
Check SHADERDIR exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,9 @@ ifeq ($(INSTALL),unix)
     ifndef SHADERDIR
         ifdef XDG_CONFIG_DIRS
             SHADERDIR = /$(firstword $(subst :, ,$(XDG_CONFIG_DIRS)))/glava/
+	    ifeq ($(wildcard $(SHADERDIR)/..),)
+                SHADERDIR = /etc/xdg/glava/
+            endif
         else
             SHADERDIR = /etc/xdg/glava/
         endif


### PR DESCRIPTION
Unity has incorrectly set XDG_CONFIG_DIRS to a path that does not exist
https://github.com/wacossusca34/glava/issues/91