### PR TITLE
Use SONAMEs when loading GLX libs dinamically

### DIFF
--- a/glx_wcb.c
+++ b/glx_wcb.c
@@ -193,8 +193,8 @@ static void init(void) {
     maximized   = false;
     transparent = false;
 
-    void* hgl  = dlopen("libGL.so", RTLD_LAZY);
-    void* hglx = dlopen("libGLX.so", RTLD_LAZY);
+    void* hgl  = dlopen("libGL.so.1", RTLD_LAZY);
+    void* hglx = dlopen("libGLX.so.0", RTLD_LAZY);
 
     if (!hgl && !hglx) {
         fprintf(stderr, "Failed to load GLX functions (libGL and libGLX do not exist!)\n");


### PR DESCRIPTION
(Related to https://github.com/void-linux/void-packages/pull/6603)

This PR makes sure to use the SONAME of the libraries when loading them dinamically, as some distros (like Void Linux) doesn't use *.so packages without proper versioning (e.g. *.so.1) unless using development package counterparts (i.e. *-dev), which shouldn't be a requirement to run GLava.