### PR TITLE
Add guiadence for fedora user to compile glava

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ sudo apt-get install libpulse0 libpulse-dev libxext6 libxext-dev libxcomposite-d
 **Fedora users:** the following command ensures you have all the needed packages and headers to compile GLava:
 ```bash
 sudo dnf install libXcomposite-devel pulseaudio-libs-devel libX11-devel libXext-devel libXrender-devel
+sudo dnf group install 'C Development Tools and Libraries'
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ You can pass `BUILD=debug` to the makefile for debug builds of both glad and gla
 sudo apt-get install libpulse0 libpulse-dev libxext6 libxext-dev libxcomposite-dev make gcc 
 ```
 
+**Fedora users:** the following command ensures you have all the needed packages and headers to compile GLava:
+```bash
+sudo dnf install libXcomposite-devel pulseaudio-libs-devel libX11-devel libXext-devel libXrender-devel
+```
+
 ## Installation
 Some distributions have a package for `glava`. If your distribution is not listed please use the compilation instructions above.
 


### PR DESCRIPTION
hello, i'm fedora user and I have installed Glava on my system with some configurations that I have written in the readme. 

## Spefications
| Info | Value |
| :--- | :---- |
| OS  | Fedora 29 |
| Desktop Environtment | KDE Plasma |
| Kernel | 4.19.15-300.fc29.x86_64 |

## Screenshoot
![image](https://user-images.githubusercontent.com/16682706/51473357-bcc43100-1dae-11e9-8952-9d3a4edd37e3.png)
