### PR TITLE
Rename parameter with typo

### DIFF
--- a/glava/render.c
+++ b/glava/render.c
@@ -618,7 +618,7 @@ static struct gl_bind_src bind_sources[] = {
 
 #define E 2.7182818284590452353
 
-void transform_smooth(struct gl_data* d, void** udaa, void* data) {
+void transform_smooth(struct gl_data* d, void** _, void* data) {
     struct gl_sampler_data* s = (struct gl_sampler_data*) data;
     float* b = s->buf;
     size_t


### PR DESCRIPTION
While reading through render.c I noticed a small typo in one of the parameter names. I assume that udaa was intended to be udata. Since the parameter is not actually used in transform_smooth at present, I have renamed it to _ as done in some of the other transform functions.