### PR TITLE
Fix build from source on archlinux

### DIFF
--- a/glava/glava.c
+++ b/glava/glava.c
@@ -76,8 +76,8 @@ static volatile bool reload = false;
 
 __attribute__((noreturn, visibility("default"))) void glava_return_builtin(void) { exit(EXIT_SUCCESS); }
 __attribute__((noreturn, visibility("default"))) void glava_abort_builtin (void) { exit(EXIT_FAILURE); }
-__attribute__((noreturn, visibility("default"))) void (*glava_return)     (void) = glava_return_builtin;
-__attribute__((noreturn, visibility("default"))) void (*glava_abort)      (void) = glava_abort_builtin;
+__attribute__((noreturn, visibility("default"))) static void (*glava_return)     (void) = glava_return_builtin;
+__attribute__((noreturn, visibility("default"))) static void (*glava_abort)      (void) = glava_abort_builtin;
 
 /* Copy installed shaders/configuration from the installed location
    (usually /etc/xdg). Modules (folders) will be linked instead of

--- a/glava/glava.h
+++ b/glava/glava.h
@@ -14,8 +14,8 @@ struct glava_renderer;
 /* External API */
 
 typedef struct glava_renderer* volatile glava_handle;
-__attribute__((noreturn, visibility("default"))) void (*glava_abort)            (void);
-__attribute__((noreturn, visibility("default"))) void (*glava_return)           (void);
+__attribute__((noreturn, visibility("default"))) static void (*glava_abort)            (void);
+__attribute__((noreturn, visibility("default"))) static void (*glava_return)           (void);
 __attribute__((visibility("default")))           void glava_assign_external_ctx (void* ctx);
 __attribute__((visibility("default")))           void glava_entry               (int argc, char** argv, glava_handle* ret);
 __attribute__((visibility("default")))           void glava_terminate           (glava_handle* ref);

--- a/glfft/glfft_gl_interface.hpp
+++ b/glfft/glfft_gl_interface.hpp
@@ -30,6 +30,8 @@ extern "C" {
     #include <stdlib.h>
     #include <string.h>
     #include <error.h>
+    #include <stdio.h>
+    #include <errno.h>
 }
 
 #ifndef GLFFT_GLSL_LANG_STRING

--- a/glfft/glfft_wisdom.cpp
+++ b/glfft/glfft_wisdom.cpp
@@ -20,6 +20,7 @@
 #include "glfft_interface.hpp"
 #include "glfft.hpp"
 #include <utility>
+#include <stdexcept>
 
 /* GLAVA NOTICE: automatic wisdom serialization support may be added at a late date */
 #ifdef GLFFT_SERIALIZATION


### PR DESCRIPTION
While compiling from source, I ran into a few errors, 

some header files were missing from glfft and there was a multiple definitions error with the function pointers in glava.h.

adding the headers missing and making the function pointers static fix the problem.

However there are warnings from the function pointers, so I'm unsure whether using static was the right option.

Here are the warnings:
```
/home/ethan/projects/C/glava/glava/glava.h:17:1: warning: ‘visibility’ attribute ignored [-Wattributes]
   17 | __attribute__((noreturn, visibility("default"))) static void (*glava_abort)            (void);
      | ^~~~~~~~~~~~~
/home/ethan/projects/C/glava/glava/glava.h:18:1: warning: ‘visibility’ attribute ignored [-Wattributes]
   18 | __attribute__((noreturn, visibility("default"))) static void (*glava_return)           (void);
      | ^~~~~~~~~~~~~
/home/ethan/projects/C/glava/glava/glava.h:18:64: warning: ‘glava_return’ defined but not used [-Wunused-variable]
   18 | __attribute__((noreturn, visibility("default"))) static void (*glava_return)           (void);
      |                                                                ^~~~~~~~~~~~
/home/ethan/projects/C/glava/glava/glava.h:17:64: warning: ‘glava_abort’ defined but not used [-Wunused-variable]
   17 | __attribute__((noreturn, visibility("default"))) static void (*glava_abort)            (void);
      |                                                                ^~~~~~~~~~~
[5/19] Compiling C object libglava.so.p/glava_glava.c.o
In file included from ../glava/render.h:8,
                 from ../glava/glava.c:18:
../glava/glava.h:17:1: warning: ‘visibility’ attribute ignored [-Wattributes]
   17 | __attribute__((noreturn, visibility("default"))) static void (*glava_abort)            (void);
      | ^~~~~~~~~~~~~
../glava/glava.h:18:1: warning: ‘visibility’ attribute ignored [-Wattributes]
   18 | __attribute__((noreturn, visibility("default"))) static void (*glava_return)           (void);
      | ^~~~~~~~~~~~~
../glava/glava.c:79:1: warning: ‘visibility’ attribute ignored [-Wattributes]
   79 | __attribute__((noreturn, visibility("default"))) static void (*glava_return)     (void) = glava_return_builtin;
      | ^~~~~~~~~~~~~
../glava/glava.c:80:1: warning: ‘visibility’ attribute ignored [-Wattributes]
   80 | __attribute__((noreturn, visibility("default"))) static void (*glava_abort)      (void) = glava_abort_builtin;
      | ^~~~~~~~~~~~~
[6/19] Compiling C object libglava.so.p/glava_xwin.c.o
In file included from ../glava/render.h:8,
                 from ../glava/xwin.c:29:
../glava/glava.h:17:1: warning: ‘visibility’ attribute ignored [-Wattributes]
   17 | __attribute__((noreturn, visibility("default"))) static void (*glava_abort)            (void);
      | ^~~~~~~~~~~~~
../glava/glava.h:18:1: warning: ‘visibility’ attribute ignored [-Wattributes]
   18 | __attribute__((noreturn, visibility("default"))) static void (*glava_return)           (void);
      | ^~~~~~~~~~~~~
../glava/glava.h:18:64: warning: ‘glava_return’ defined but not used [-Wunused-variable]
   18 | __attribute__((noreturn, visibility("default"))) static void (*glava_return)           (void);
      |                                                                ^~~~~~~~~~~~
[7/19] Compiling C object libglava.so.p/glava_glx_wcb.c.o
In file included from ../glava/render.h:8,
                 from ../glava/glx_wcb.c:25:
../glava/glava.h:17:1: warning: ‘visibility’ attribute ignored [-Wattributes]
   17 | __attribute__((noreturn, visibility("default"))) static void (*glava_abort)            (void);
      | ^~~~~~~~~~~~~
../glava/glava.h:18:1: warning: ‘visibility’ attribute ignored [-Wattributes]
   18 | __attribute__((noreturn, visibility("default"))) static void (*glava_return)           (void);
      | ^~~~~~~~~~~~~
../glava/glava.h:18:64: warning: ‘glava_return’ defined but not used [-Wunused-variable]
   18 | __attribute__((noreturn, visibility("default"))) static void (*glava_return)           (void);
      |                                                                ^~~~~~~~~~~~
[8/19] Compiling C object libglava-obs.so.p/glava-obs_entry.c.o
In file included from ../glava-obs/entry.c:7:
../glava-obs/../glava/glava.h:17:1: warning: ‘visibility’ attribute ignored [-Wattributes]
   17 | __attribute__((noreturn, visibility("default"))) static void (*glava_abort)            (void);
      | ^~~~~~~~~~~~~
../glava-obs/../glava/glava.h:18:1: warning: ‘visibility’ attribute ignored [-Wattributes]
   18 | __attribute__((noreturn, visibility("default"))) static void (*glava_return)           (void);
      | ^~~~~~~~~~~~~
../glava-obs/../glava/glava.h:18:64: warning: ‘glava_return’ defined but not used [-Wunused-variable]
   18 | __attribute__((noreturn, visibility("default"))) static void (*glava_return)           (void);
      |                                                                ^~~~~~~~~~~~
../glava-obs/../glava/glava.h:17:64: warning: ‘glava_abort’ defined but not used [-Wunused-variable]
   17 | __attribute__((noreturn, visibility("default"))) static void (*glava_abort)            (void);
      |                                                                ^~~~~~~~~~~
[10/19] Compiling C object libglava.so.p/glava_glsl_ext.c.o
In file included from ../glava/glsl_ext.c:16:
../glava/glava.h:17:1: warning: ‘visibility’ attribute ignored [-Wattributes]
   17 | __attribute__((noreturn, visibility("default"))) static void (*glava_abort)            (void);
      | ^~~~~~~~~~~~~
../glava/glava.h:18:1: warning: ‘visibility’ attribute ignored [-Wattributes]
   18 | __attribute__((noreturn, visibility("default"))) static void (*glava_return)           (void);
      | ^~~~~~~~~~~~~
../glava/glava.h:18:64: warning: ‘glava_return’ defined but not used [-Wunused-variable]
   18 | __attribute__((noreturn, visibility("default"))) static void (*glava_return)           (void);
      |                                                                ^~~~~~~~~~~~
[13/19] Compiling C object libglava.so.p/glava_render.c.o
In file included from ../glava/render.h:8,
                 from ../glava/render.c:20:
../glava/glava.h:17:1: warning: ‘visibility’ attribute ignored [-Wattributes]
   17 | __attribute__((noreturn, visibility("default"))) static void (*glava_abort)            (void);
      | ^~~~~~~~~~~~~
../glava/glava.h:18:1: warning: ‘visibility’ attribute ignored [-Wattributes]
   18 | __attribute__((noreturn, visibility("default"))) static void (*glava_return)           (void);
      | ^~~~~~~~~~~~~
../glava/glava.h:18:64: warning: ‘glava_return’ defined but not used [-Wunused-variable]
   18 | __attribute__((noreturn, visibility("default"))) static void (*glava_return)           (void);
      |                      
```