### PR TITLE
Fixed compiler and linker errors

### DIFF
--- a/glava/glava.h
+++ b/glava/glava.h
@@ -14,8 +14,8 @@ struct glava_renderer;
 /* External API */
 
 typedef struct glava_renderer* volatile glava_handle;
-__attribute__((noreturn, visibility("default"))) void (*glava_abort)            (void);
-__attribute__((noreturn, visibility("default"))) void (*glava_return)           (void);
+__attribute__((noreturn, visibility("default"))) extern void (*glava_abort)            (void);
+__attribute__((noreturn, visibility("default"))) extern void (*glava_return)           (void);
 __attribute__((visibility("default")))           void glava_assign_external_ctx (void* ctx);
 __attribute__((visibility("default")))           void glava_entry               (int argc, char** argv, glava_handle* ret);
 __attribute__((visibility("default")))           void glava_terminate           (glava_handle* ref);

--- a/glfft/glfft_common.hpp
+++ b/glfft/glfft_common.hpp
@@ -25,6 +25,7 @@
 #include <functional>
 #include <cstddef>
 #include <cstdlib>
+#include <stdexcept>
 #include <string>
 #include <cstring>
 #include <memory>

--- a/glfft/glfft_gl_interface.hpp
+++ b/glfft/glfft_gl_interface.hpp
@@ -30,6 +30,8 @@ extern "C" {
     #include <stdlib.h>
     #include <string.h>
     #include <error.h>
+    #include <errno.h>
+    #include <stdio.h>
 }
 
 #ifndef GLFFT_GLSL_LANG_STRING


### PR DESCRIPTION
This should fix undefined scope errors for fprintf, stdout, and logic_error in glfft, and prevent a multiple definition error for glava_abort and glava_return.