### PR TITLE
Improve meson setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ export CFLAGS
 
 BUILD_DIR = build
 
-MESON_CONF = $(BUILD_DIR) -Ddisable_obs=true -Ddisable_config=true --prefix /usr
+MESON_CONF = $(BUILD_DIR) -Dobs=false -Dconfig-tool=false --prefix /usr
 
 # Support assigning standalone/debug builds as the old Makefile did, otherwise complain
 

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ Note that versions since `2.0` use Meson for the build system, although the `Mak
 **Additional compile time requirements:**
 
 - Meson
-- OBS (disable with `-Ddisable_obs=true`)
+- OBS (disable with `-Dobs=false`)
 
 **Optional requirements:**
 
-- GLFW 3.1+ (optional, enable with `-Denable_glfw=true`)
+- GLFW 3.1+ (optional, enable with `-Dglfw=true`)
 
 **Ubuntu/Debian users:** the following command ensures you have all the needed packages and headers to compile GLava with the default feature set:
 ```bash

--- a/meson.build
+++ b/meson.build
@@ -50,12 +50,12 @@ if host_machine.system() == 'darwin'
   # shader_dir = '/Library/glava/'
 endif
 
-if get_option('enable_glfw')
+if get_option('glfw')
   add_project_arguments('-DGLAVA_GLFW', language: ['cpp', 'c'])
   glava_dependencies += cc.find_library('glfw')
 endif
 
-if not get_option('disable_glx')
+if get_option('glx')
   add_project_arguments('-DGLAVA_GLX', language: ['cpp', 'c'])
   glava_dependencies += cc.find_library('Xrender')
 endif
@@ -98,7 +98,7 @@ executable(
   c_args:    ['-I' + meson.source_root() + '/glava', '-std=c++11'],
   install:   true)
 
-if not get_option('disable_config')
+if get_option('config-tool')
   
   # Generator and target for lua objects used by `glava-config`.
   # This has been written such that ninja can detect when sources
@@ -180,7 +180,7 @@ if not get_option('disable_config')
   endif
 endif
 
-if not get_option('disable_obs')
+if get_option('obs')
   shared_library(
     'glava-obs',
 	install:     true,

--- a/meson.build
+++ b/meson.build
@@ -20,10 +20,10 @@ endif
 
 glava_dependencies = [
   dependency('threads'),
-  cc.find_library('pulse'),
-  cc.find_library('pulse-simple'),
-  cc.find_library('dl'),
-  cc.find_library('m'),
+  dependency('libpulse'),
+  dependency('libpulse-simple'),
+  cc.find_library('dl', required: false),
+  cc.find_library('m', required: false),
   cc.find_library('X11'),
   cc.find_library('Xext')
 ]
@@ -52,7 +52,7 @@ endif
 
 if get_option('glfw')
   add_project_arguments('-DGLAVA_GLFW', language: ['cpp', 'c'])
-  glava_dependencies += cc.find_library('glfw')
+  glava_dependencies += dependency('glfw3')
 endif
 
 if get_option('glx')
@@ -82,7 +82,7 @@ glfft = static_library(
   sources: run_command('find', 'glfft', '-type', 'f', '-name', '*.cpp', '-print')
            .stdout().strip().split('\n'),
   c_args: ['-std=c++11'],
-  dependencies: [ cc.find_library('dl') ])
+  dependencies: [ cc.find_library('dl', required: false) ])
 
 libglava = shared_library(
   'glava',
@@ -187,14 +187,13 @@ if get_option('obs')
     install_dir: get_option('obs_plugin_install_dir'),
     sources:     'glava-obs/entry.c',
     link_with:   libglava,
-    c_args:      '-I/usr/include/obs',
     dependencies: [
-	  dependency('threads'),
-	  cc.find_library('GL'),
-	  cc.find_library('X11'),
-      cc.find_library('obs'),
-	  cc.find_library('dl')
-	])
+      dependency('threads'),
+      dependency('GL'),
+      cc.find_library('X11'),
+      dependency('libobs'),
+      cc.find_library('dl', required: false)
+    ])
 endif
 
 install_subdir('shaders/glava', install_dir: shader_dir)

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
   'glava',
   ['c', 'cpp'],
   version: run_command('git', 'describe', '--tags').stdout().strip(),
-  default_options:['buildtype=release', 'strip=true', 'optimization=2'])
+  default_options:['buildtype=release', 'strip=true', 'optimization=2', 'cpp_std=c++11'])
 
 cc = meson.get_compiler('c')
 
@@ -73,30 +73,30 @@ add_project_arguments(
   '-DGLAVA_VERSION="' + glava_version + '"',
   '-DSHADER_INSTALL_PATH="' + shader_dir + '/glava"',
   '-DGLAVA_RESOURCE_PATH="' + resource_dir + '/resources"',
-  # todo: add back
-  # '-fvisibility=hidden',
   language: ['cpp', 'c'])
 
 glfft = static_library(
   'glfft',
   sources: run_command('find', 'glfft', '-type', 'f', '-name', '*.cpp', '-print')
            .stdout().strip().split('\n'),
-  c_args: ['-std=c++11'],
-  dependencies: [ cc.find_library('dl', required: false) ])
+  dependencies: [ cc.find_library('dl', required: false) ],
+  gnu_symbol_visibility: 'hidden')
 
 libglava = shared_library(
   'glava',
   sources: run_command('find', 'glava', '-type', 'f', '-name', '*.c', '-print')
            .stdout().strip().split('\n'),
   dependencies: glava_dependencies,
-  install:      true)
+  install:      true,
+  gnu_symbol_visibility: 'hidden')
 
 executable(
   'glava',
   sources:   'glava-cli/cli.c',
   link_with: libglava,
-  c_args:    ['-I' + meson.source_root() + '/glava', '-std=c++11'],
-  install:   true)
+  include_directories: include_directories('glava'),
+  install:   true,
+  gnu_symbol_visibility: 'hidden')
 
 if get_option('config-tool')
   
@@ -160,7 +160,8 @@ if get_option('config-tool')
     dependencies: [
 	  cc.find_library('X11'),
       cc.find_library(lua_impl + lua_ver)
-    ])
+    ],
+    gnu_symbol_visibility: 'hidden')
   
   # Local glava-config environment symlink for standalone execution
   if get_option('standalone')
@@ -193,7 +194,8 @@ if get_option('obs')
       cc.find_library('X11'),
       dependency('libobs'),
       cc.find_library('dl', required: false)
-    ])
+    ],
+    gnu_symbol_visibility: 'hidden')
 endif
 
 install_subdir('shaders/glava', install_dir: shader_dir)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,14 +1,14 @@
-option('enable_glfw', type: 'boolean', value: false,
+option('glfw', type: 'boolean', value: false,
        description: 'Enable legacy GLFW backend')
-option('disable_glx', type: 'boolean', value: false,
-       description: 'Disable GLX backend')
+option('glx', type: 'boolean', value: true,
+       description: 'Enable GLX backend')
 option('standalone', type: 'boolean', value: false,
        description: 'Configure build to run without installation')
 option('glad', type: 'boolean', value: false,
        description: 'Download and build GLAD headers (non-reproducable)')
-option('disable_obs', type: 'boolean', value: false,
-       description: 'Disable OBS Studio plugin support')
-option('disable_config', type: 'boolean', value: true,
+option('obs', type: 'boolean', value: true,
+       description: 'Enable OBS Studio plugin support')
+option('config-tool', type: 'boolean', value: false,
        description: 'Skip building GLava GTK+ configuration tool')
 option('shader_install_dir', type: 'string', value: '/etc/xdg',
        description: 'GLSL config/module system install directory')


### PR DESCRIPTION
A variety of things to update and modernize the Meson setup. It would also be good to set a minimum Meson version in your `project` call, as there are other things that could be done, but I wasn't sure if it would be too new.

* Rename Meson option names to be more conventional.
  It is [recommended](https://mesonbuild.com/Style-guide.html#naming-options) to not use (enable|disable) prefix on option names, as this is not autoconf.
* Packages that provide a pkg-config file or are supported by Meson should use `dependency`, not `find_library`.
* Both `dl` and `m` are glibc-specific, and should be optional in order to build on other systems.
* Set `cpp_std` as a build option, use `include_directories`, and enable hidden symbol visibility again.

I would also say you should explicitly list out the files instead of using `find`, but you do that so much I didn't want to do that out of the blue.